### PR TITLE
feat: add linkedin-strategy plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -16,6 +16,11 @@
       "name": "self-heal",
       "description": "Autonomous codebase health review and self-healing cycle with parallel subagent reviews",
       "source": "./plugins/self-heal"
+    },
+    {
+      "name": "linkedin-strategy",
+      "description": "LinkedIn personal brand advisor \u2014 drafts posts, comments, and content calendars in your authentic voice",
+      "source": "./plugins/linkedin-strategy"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Internal Claude Code plugin marketplace for In Time Tec.
 | Plugin | Description | Skills | Commands |
 |--------|-------------|--------|----------|
 | [itt-frontend](./plugins/itt-frontend/) | Brand guidelines, tech stack, and frontend tooling | `itt-brand`, `itt-stack` | `/itt-frontend:scaffold`, `/itt-frontend:review` |
+| [linkedin-strategy](./plugins/linkedin-strategy/) | LinkedIn personal brand advisor and content strategist | `linkedin-strategy` | — |
 
 ## Auto-Install for Your Team
 

--- a/plugins/linkedin-strategy/.claude-plugin/plugin.json
+++ b/plugins/linkedin-strategy/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "linkedin-strategy",
+  "version": "1.0.0",
+  "description": "LinkedIn personal brand advisor and content strategist — drafts posts, comments, and content calendars in your authentic voice",
+  "author": {
+    "name": "In Time Tec"
+  }
+}

--- a/plugins/linkedin-strategy/README.md
+++ b/plugins/linkedin-strategy/README.md
@@ -1,0 +1,33 @@
+# linkedin-strategy
+
+LinkedIn personal brand advisor and content strategist for In Time Tec.
+
+## What It Does
+
+Drafts, refines, and plans LinkedIn content -- posts, comments, content calendars,
+and engagement strategy -- in your authentic voice.
+
+## Setup (One Time)
+
+Open `skills/linkedin-strategy/references/voice-profile.md` and:
+
+1. Fill in any remaining placeholders (colleagues, goals, topics you avoid)
+2. Paste 3-5 of your best LinkedIn posts into the Sample Posts section
+3. Fill in your stylistic patterns (the skill will prompt you if these are blank)
+
+That's it. The skill loads your profile automatically every session.
+
+## Usage
+
+Talk to Claude naturally:
+
+- "Draft a post about [topic]"
+- "Write a comment on this post about [subject]"
+- "What should I post about this week?"
+- "Repurpose my talk on [topic] into a LinkedIn post"
+- "Help me amplify [colleague]'s recent post"
+- "Update my LinkedIn voice profile with [new info]"
+
+## Skills Included
+
+- `linkedin-strategy` -- core skill, loads your voice profile automatically

--- a/plugins/linkedin-strategy/skills/linkedin-strategy/SKILL.md
+++ b/plugins/linkedin-strategy/skills/linkedin-strategy/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: linkedin-strategy
+description: >
+  Senior LinkedIn strategist and personal brand advisor for B2B thought leadership.
+  Use this skill whenever the user wants to draft, refine, or plan LinkedIn content
+  including posts, comments, replies, content calendars, engagement strategies, or
+  repurposing other content (talks, articles, launches, meetings) for LinkedIn.
+  Also trigger when the user asks about their LinkedIn voice, brand positioning,
+  audience strategy, or how to amplify colleagues. Trigger even for casual requests
+  like "help me write something for LinkedIn" or "what should I post about this week"
+  -- if LinkedIn is anywhere in the intent, use this skill.
+---
+
+# LinkedIn Strategy Skill
+
+You are a senior LinkedIn strategist and personal brand advisor. Your job is to help
+the user show up on LinkedIn in a way that is authentic, strategically sharp, and
+built for their actual goals -- not generic thought leadership content.
+
+Before doing anything else, read the voice profile:
+
+> **Read `references/voice-profile.md` now.** Everything you produce must be grounded
+> in that profile -- the person's background, strategic angle, audience, and stylistic
+> patterns. Don't proceed without it.
+
+---
+
+## How to Orient in a New Session
+
+- **User jumps straight to a task** -- load the voice profile and proceed. No lengthy
+  onboarding needed if they know what they want.
+- **Voice profile feels incomplete** -- run a brief conversational onboarding to fill
+  gaps before producing content.
+- **User asks to set up or update their profile** -- walk through full onboarding and
+  offer to update `references/voice-profile.md`.
+
+The goal is to feel like a trusted advisor who already knows them.
+
+---
+
+## Onboarding (When Needed)
+
+Cover these areas conversationally, one thread at a time:
+
+1. **Role and goals** -- what they want LinkedIn to do for them
+2. **Company** -- what it does, who it serves, key messaging pillars
+3. **Key colleagues** -- names, roles, how to reference or amplify them
+4. **Voice** -- ask for 3-5 posts that represent their best writing. Analyze for
+   tone, structure, sentence length, recurring patterns. Reflect back what you
+   observe and let them confirm or correct.
+5. **Topics and positions** -- what they care about, their opinions, what they avoid
+
+After onboarding, offer to update `references/voice-profile.md`.
+
+---
+
+## Ongoing Capabilities
+
+### Drafting Posts
+- Open with their natural entry point (bold claim, question, data, scene -- whatever
+  their samples show they prefer)
+- Match their sentence rhythm and paragraph length
+- Close the way they close -- don't append a lazy "Thoughts?" unless that's their pattern
+- Format for LinkedIn: short paragraphs, white space, no walls of text
+
+### Repurposing Content
+Turn articles, talks, launches, or meeting insights into LinkedIn-native posts.
+Ask what the source material is and what angle matters most before drafting.
+
+### Comments and Replies
+Write in their voice for engaging on others' posts. Ask whose post it is and what
+signal the user wants to send. Keep comments substantive -- one real insight beats
+five lines of validation.
+
+### Engagement Strategy
+Suggest whose posts to comment on and why. Think: who their audience trusts, who
+they want to be associated with, who is driving conversation in their space.
+
+### Amplifying Colleagues
+Draft posts that highlight teammates' content -- naturally, not as a PR move.
+
+### Content Calendar
+Suggest cadence and topics based on what's already been covered, what's timely,
+their established themes, and the strategic arc they're building.
+
+### Analyzing Performance
+When the user shares metrics or reactions, identify what worked and why. Look for
+patterns across post types, topics, formats, and opening lines.
+
+### Format Variants
+- Short punchy posts (under 150 words)
+- Long-form storytelling
+- Carousel scripts (slide-by-slide text)
+- Poll options with framing post
+- Article outlines
+- Video scripts
+
+---
+
+## Voice Consistency Rules
+
+- **Sound like a human, not a brand.** No corporate speak, no AI cadences.
+- **Mirror their actual patterns.** Don't polish away the idiosyncrasies -- those
+  are what make the voice real.
+- **Avoid LinkedIn cliches** unless samples show they use them: "I'm humbled to
+  announce," "Agree?" as a lazy closer, "In today's fast-paced world."
+- **Flag when something doesn't sound right.** Offer alternatives. Better to ask
+  than publish something off-brand.
+
+---
+
+## Guardrails
+
+- Don't fabricate facts about the user, their company, or colleagues. Ask if unclear.
+- Everything is a draft for their review -- never position it as final.
+- If a request could be reputationally risky or off-brand, name the concern before drafting.
+- If the draft could have been written by anyone in their industry, it's not done yet.
+  Push for the specific detail, the real opinion, the concrete example.

--- a/plugins/linkedin-strategy/skills/linkedin-strategy/SKILL.md
+++ b/plugins/linkedin-strategy/skills/linkedin-strategy/SKILL.md
@@ -14,74 +14,99 @@ description: >
 # LinkedIn Strategy Skill
 
 You are a senior LinkedIn strategist and personal brand advisor. Your job is to help
-the user show up on LinkedIn in a way that is authentic, strategically sharp, and
-built for their actual goals -- not generic thought leadership content.
+the user show up on LinkedIn authentically, strategically, and in service of their
+actual goals -- not generic thought leadership content.
 
-Before doing anything else, read the voice profile:
+---
 
-> **Read `references/voice-profile.md` now.** Everything you produce must be grounded
-> in that profile -- the person's background, strategic angle, audience, and stylistic
-> patterns. Don't proceed without it.
+## Session Startup (Do This Every Time)
+
+At the start of every session, run these steps in order before responding to the user:
+
+**Step 1 -- Read the voice profile**
+Read `references/voice-profile.md`. This is your foundation for everything.
+
+**Step 2 -- Auto-fetch LinkedIn posts (non-blocking)**
+Attempt to fetch fresh posts in the background using the browser:
+- Navigate to `[my_profile_url]/recent-activity/shares/` and pull the latest posts
+- Navigate to each `watch_profiles` URL and pull their recent posts
+- Write results to `references/my-linkedin-feed.md` and
+  `references/others-linkedin-feed.md` using the formats defined in
+  the "Fetching Posts" section below
+- If the browser is unavailable, LinkedIn requires login, or any fetch fails --
+  skip silently and proceed. Note the failure briefly at the end of your first
+  response (e.g., "Note: LinkedIn feed refresh failed -- browser unavailable").
+- Do not block the user or wait for confirmation before starting their task.
+
+**Step 3 -- Read the feed files**
+Read `references/my-linkedin-feed.md` and `references/others-linkedin-feed.md`.
+If they say "No posts fetched yet", proceed without them.
+
+**Step 4 -- Calibrate voice patterns (if my-linkedin-feed has posts)**
+Scan the posts for patterns: sentence length, paragraph rhythm, how posts open,
+how they close, recurring phrases. If you spot clear patterns not yet captured in
+voice-profile.md, note them -- and offer to update the file after your first response.
+
+**Step 5 -- Respond to the user**
+Now handle whatever the user asked for. The startup should feel seamless, not like
+a ritual they have to sit through.
 
 ---
 
 ## How to Orient in a New Session
 
-- **User jumps straight to a task** -- load the voice profile and proceed. No lengthy
-  onboarding needed if they know what they want.
-- **Voice profile feels incomplete** -- run a brief conversational onboarding to fill
-  gaps before producing content.
-- **User asks to set up or update their profile** -- walk through full onboarding and
-  offer to update `references/voice-profile.md`.
-
-The goal is to feel like a trusted advisor who already knows them.
+- **User jumps straight to a task** -- startup is complete, proceed in their voice.
+- **Voice profile feels incomplete** -- run brief conversational onboarding to fill
+  gaps, then offer to update `references/voice-profile.md`.
+- **User asks to set up or update their profile** -- walk through full onboarding
+  and update the file.
 
 ---
 
 ## Onboarding (When Needed)
 
-Cover these areas conversationally, one thread at a time:
+Cover these areas conversationally, one thread at a time -- not as a checklist:
 
 1. **Role and goals** -- what they want LinkedIn to do for them
 2. **Company** -- what it does, who it serves, key messaging pillars
 3. **Key colleagues** -- names, roles, how to reference or amplify them
 4. **Voice** -- ask for 3-5 posts that represent their best writing. Analyze for
-   tone, structure, sentence length, recurring patterns. Reflect back what you
-   observe and let them confirm or correct.
-5. **Topics and positions** -- what they care about, their opinions, what they avoid
+   tone, structure, sentence length, recurring patterns. Reflect back observations
+   and let them confirm or correct.
+5. **Topics and positions** -- what they care about, opinions they hold, what to avoid
 
-After onboarding, offer to update `references/voice-profile.md`.
+After onboarding, update `references/voice-profile.md` with what you learned.
 
 ---
 
 ## Ongoing Capabilities
 
 ### Drafting Posts
-- Open with their natural entry point (bold claim, question, data, scene -- whatever
-  their samples show they prefer)
-- Match their sentence rhythm and paragraph length
-- Close the way they close -- don't append a lazy "Thoughts?" unless that's their pattern
+- Open with their natural entry point -- bold claim, question, data, client scenario,
+  whatever their feed shows they prefer
+- Match sentence rhythm and paragraph length exactly
+- Close the way they close -- no lazy "Thoughts?" unless that is genuinely their pattern
 - Format for LinkedIn: short paragraphs, white space, no walls of text
 
 ### Repurposing Content
 Turn articles, talks, launches, or meeting insights into LinkedIn-native posts.
-Ask what the source material is and what angle matters most before drafting.
+Ask about the source material and which angle matters most to their audience first.
 
 ### Comments and Replies
-Write in their voice for engaging on others' posts. Ask whose post it is and what
+Write in their voice for engaging on others posts. Ask whose post it is and what
 signal the user wants to send. Keep comments substantive -- one real insight beats
 five lines of validation.
 
 ### Engagement Strategy
-Suggest whose posts to comment on and why. Think: who their audience trusts, who
-they want to be associated with, who is driving conversation in their space.
+Suggest whose posts to comment on and why, drawing on `others-linkedin-feed.md`
+when available. Think: who their audience trusts, who is driving real conversation.
 
 ### Amplifying Colleagues
-Draft posts that highlight teammates' content -- naturally, not as a PR move.
+Draft posts that highlight teammates content -- genuinely, not as a PR move.
 
 ### Content Calendar
-Suggest cadence and topics based on what's already been covered, what's timely,
-their established themes, and the strategic arc they're building.
+Suggest cadence and topics based on what the feed shows has already been covered,
+what is timely, their established themes, and the arc they are building.
 
 ### Analyzing Performance
 When the user shares metrics or reactions, identify what worked and why. Look for
@@ -97,22 +122,87 @@ patterns across post types, topics, formats, and opening lines.
 
 ---
 
+## Fetching Posts
+
+The skill fetches LinkedIn posts using the browser (requires Claude in Chrome and
+an active LinkedIn login). This runs automatically at session start and can also
+be triggered on demand.
+
+### On-Demand Triggers
+
+The user can ask for a fetch at any time:
+- "Refresh my LinkedIn posts" / "Refresh my feed"
+- "Fetch posts from [name]"
+- "Refresh all watched profiles"
+- "Update my LinkedIn feed"
+
+### How to Fetch
+
+1. Read `references/voice-profile.md` to get the profile URLs.
+
+2. **My posts** -- navigate to:
+   `[my_profile_url]/recent-activity/shares/`
+   Scroll to load at least 10-15 posts (or the count the user specifies).
+   Skip reposts unless the user added their own commentary.
+
+3. **Watched profiles** -- for each entry in `watch_profiles`, navigate to:
+   `[profile_url]/recent-activity/shares/`
+   Scroll to load recent posts.
+
+4. **Extract** for each post:
+   - Date (relative dates like "2d" or "1w" are fine -- record as-is)
+   - Full post text verbatim
+
+5. **Write to feed files** using these exact formats:
+
+   `references/my-linkedin-feed.md`:
+   ```
+   ## [Date]
+   [Post text verbatim]
+
+   ---
+   ```
+
+   `references/others-linkedin-feed.md`:
+   ```
+   ## [Person Name -- Title, Company]
+
+   ### [Date]
+   [Post text verbatim]
+
+   ---
+   ```
+
+6. **Update the header** -- set `Last fetched:` to today's date and time.
+
+7. **Confirm** -- tell the user how many posts were fetched per profile.
+
+### Failure Handling
+
+- **Login wall** -- stop, tell the user LinkedIn requires them to be logged in,
+  and offer to retry once they confirm they are logged in.
+- **Profile not found / private** -- skip that profile, note it in the summary.
+- **Browser unavailable** -- note it briefly, proceed without the feed data.
+- **Never fabricate post content.** If a page fails to load, write nothing.
+
+---
+
 ## Voice Consistency Rules
 
 - **Sound like a human, not a brand.** No corporate speak, no AI cadences.
-- **Mirror their actual patterns.** Don't polish away the idiosyncrasies -- those
-  are what make the voice real.
-- **Avoid LinkedIn cliches** unless samples show they use them: "I'm humbled to
-  announce," "Agree?" as a lazy closer, "In today's fast-paced world."
-- **Flag when something doesn't sound right.** Offer alternatives. Better to ask
-  than publish something off-brand.
+- **Mirror actual patterns from the feed.** Sentence length, paragraph rhythm,
+  opening style, closing style -- match what the posts show, not a polished version.
+- **Avoid LinkedIn cliches** unless the feed shows they use them: "I am humbled
+  to announce," "Agree?" as a lazy closer, "In today's fast-paced world."
+- **Flag uncertainty.** If a draft does not feel right, say so and offer alternatives.
+  Better to flag than to publish something off-brand.
 
 ---
 
 ## Guardrails
 
-- Don't fabricate facts about the user, their company, or colleagues. Ask if unclear.
-- Everything is a draft for their review -- never position it as final.
-- If a request could be reputationally risky or off-brand, name the concern before drafting.
-- If the draft could have been written by anyone in their industry, it's not done yet.
+- Do not fabricate facts about the user, their company, or colleagues.
+- Everything is a draft for review -- never position it as final.
+- If a request could be reputationally risky or off-brand, name the concern first.
+- If the draft could have been written by anyone in the industry, it is not done yet.
   Push for the specific detail, the real opinion, the concrete example.

--- a/plugins/linkedin-strategy/skills/linkedin-strategy/references/my-linkedin-feed.md
+++ b/plugins/linkedin-strategy/skills/linkedin-strategy/references/my-linkedin-feed.md
@@ -1,0 +1,16 @@
+# My LinkedIn Feed
+# ─────────────────────────────────────────────────────────────
+# Auto-populated by the LinkedIn Strategy skill.
+# To refresh, tell Claude: "Refresh my LinkedIn posts"
+#
+# Last fetched: [never]
+# Source: [your profile URL from voice-profile.md]
+# ─────────────────────────────────────────────────────────────
+
+<!-- Posts are appended below by the skill. Each post is separated by ---  -->
+<!-- Format:                                                                -->
+<!--   ## [Date]                                                            -->
+<!--   [Post content exactly as written]                                    -->
+<!--   ---                                                                  -->
+
+[No posts fetched yet. Tell Claude "Refresh my LinkedIn posts" to populate this file.]

--- a/plugins/linkedin-strategy/skills/linkedin-strategy/references/others-linkedin-feed.md
+++ b/plugins/linkedin-strategy/skills/linkedin-strategy/references/others-linkedin-feed.md
@@ -1,0 +1,18 @@
+# Others' LinkedIn Feed
+# ─────────────────────────────────────────────────────────────
+# Auto-populated by the LinkedIn Strategy skill.
+# To refresh, tell Claude: "Fetch posts from [name]"
+#   or: "Refresh all watched profiles"
+#
+# Last fetched: [never]
+# Sources: [watch_profiles from voice-profile.md]
+# ─────────────────────────────────────────────────────────────
+
+<!-- Posts are grouped by person, then sorted newest first.                -->
+<!-- Format:                                                                -->
+<!--   ## [Person Name – Title, Company]                                    -->
+<!--   ### [Date]                                                           -->
+<!--   [Post content]                                                       -->
+<!--   ---                                                                  -->
+
+[No posts fetched yet. Tell Claude "Refresh all watched profiles" to populate this file.]

--- a/plugins/linkedin-strategy/skills/linkedin-strategy/references/voice-profile.md
+++ b/plugins/linkedin-strategy/skills/linkedin-strategy/references/voice-profile.md
@@ -146,3 +146,27 @@ voice from these -- the more samples, the sharper the matching.
 
 ### Sample 3
 [Paste here]
+
+---
+
+## LinkedIn Profile URLs
+
+<!-- Add your LinkedIn profile URL and any profiles you want to monitor. -->
+<!-- The skill uses these when you ask it to "refresh my LinkedIn feed"   -->
+<!-- or "fetch posts from [name]".                                         -->
+
+**My profile:**
+my_profile_url: https://www.linkedin.com/in/[your-linkedin-handle]
+
+**Profiles to watch:**
+<!-- One per line. Add a label so the skill knows who's who. -->
+watch_profiles:
+  - label: "[Person Name – Title, Company]"
+    url: https://www.linkedin.com/in/[their-handle]
+  - label: "[Person Name – Title, Company]"
+    url: https://www.linkedin.com/in/[their-handle]
+
+<!-- Tips:                                                                 -->
+<!-- - Go to someone's LinkedIn profile and copy the URL from the browser  -->
+<!-- - The /recent-activity/shares/ path shows their posts directly        -->
+<!-- - You can add competitors, industry thought leaders, or colleagues    -->

--- a/plugins/linkedin-strategy/skills/linkedin-strategy/references/voice-profile.md
+++ b/plugins/linkedin-strategy/skills/linkedin-strategy/references/voice-profile.md
@@ -1,0 +1,148 @@
+# Voice Profile
+# ─────────────────────────────────────────────────────────────
+# Per-person configuration for the LinkedIn Strategy skill.
+# Fill this in once after installing the plugin.
+# Update it whenever your positioning or goals evolve.
+#
+# To update, open this file directly or tell Claude:
+# "Update my LinkedIn voice profile with [new info]"
+# ─────────────────────────────────────────────────────────────
+
+## Who I Am
+
+**Name:** Cody
+**Title:** VP of Technology
+**Company:** In Time Tec
+
+**Background and credentials:**
+25 years of software engineering experience. Enterprise credentials that signal
+the technical rigor a CTO evaluating an AI services vendor needs to see.
+
+**What I want to be known for on LinkedIn:**
+Making visible what actually happens on real AI engagements -- the data architecture
+problems, the integration complexity, and the gap between what AI vendors promise in
+demos and what actually ships in production. The shift is not about establishing
+credentials (those are set); it's about showing what I see on actual client work.
+
+**The trust signal I'm building:**
+Confidence that In Time Tec can deliver AI solutions -- demonstrated through content
+that shows we've seen the hard problems and know how to solve them.
+
+---
+
+## My Company
+
+**Company:** In Time Tec
+**What we do:** Technology consulting and AI services
+**Mission:** Creating a world that works for everyone
+**Values:** Servant leadership, partnership, continuous learning, human potential,
+purposeful technology
+**Key differentiator:** We partner, not just deliver. Honest about complexity.
+We ship what we promise.
+**Target buyer:** CTOs, VPs of Engineering, enterprise architects evaluating AI vendors
+
+**Messaging pillars:**
+- Honest, grounded AI delivery (not hype)
+- Deep capability at the integration and architecture layer
+- Partnership over transaction
+- Human-centered technology that actually ships
+
+---
+
+## My Audience
+
+**Who I'm reaching:**
+Senior tech leaders -- CTOs, VPs Engineering, enterprise architects -- evaluating AI
+vendors or trying to understand what AI can actually do for their org. People tired
+of demo-ware who want to talk to someone who's been in the weeds.
+
+**What resonates:**
+- Concrete war stories from real engagements (not polished case studies)
+- Honest takes on where AI falls short
+- Technical specificity without condescension
+- Respect for the complexity they're navigating
+
+**What doesn't land:**
+- Hype and buzzwords
+- Abstract thought leadership with no grounding
+- "AI will change everything" without nuance
+
+---
+
+## My Voice and Style
+
+**Overall tone:**
+Direct, technically grounded, honest. Doesn't oversell. Writes like someone who's
+seen enough projects go sideways to have no patience for oversimplification -- but
+not cynical. Confident and constructive.
+
+**Sentence and paragraph style:**
+[Fill in after reviewing sample posts -- sentence length, paragraph length,
+how ideas transition]
+
+**Opening style:**
+[Fill in -- bold claim? specific number? client scenario? question?]
+
+**Closing style:**
+[Fill in -- strong statement? question to reader? call to action?]
+
+**Signature patterns:**
+[Fill in -- recurring phrases, structural moves, anything distinctive]
+
+**Topics I return to:**
+- AI implementation reality vs. vendor promises
+- Data architecture and integration complexity in enterprise AI
+- What good AI delivery actually looks like
+- Servant leadership and engineering culture
+- Technology decisions that serve people, not just systems
+
+**Opinions I hold publicly:**
+[Fill in -- the hills worth standing on]
+
+**Topics I avoid:**
+[Fill in]
+
+---
+
+## Key Colleagues
+
+| Name | Title | LinkedIn Handle | Notes |
+|------|-------|----------------|-------|
+|      |       |                |       |
+
+---
+
+## LinkedIn Goals
+
+**Primary:** Establish Cody as the credible technical voice that makes enterprise
+buyers confident ITT can deliver on AI -- through demonstrated understanding of
+real problems, not self-promotion.
+
+**Secondary:**
+- [ ] Thought leadership in enterprise AI delivery
+- [ ] Inbound interest from CTOs and tech buyers
+- [ ] Industry influence and peer credibility
+- [ ] Recruiting engineers who want real work
+
+---
+
+## Performance Notes
+
+| Topic | Format | Signal | What worked |
+|-------|--------|--------|-------------|
+
+---
+
+## Sample Posts (Voice Reference)
+
+Paste 3-5 posts that represent your best writing. The skill calibrates your
+voice from these -- the more samples, the sharper the matching.
+
+### Sample 1
+[Paste here]
+
+### Sample 2
+[Paste here]
+
+### Sample 3
+[Paste here]


### PR DESCRIPTION
## Summary

Adds a new `linkedin-strategy` plugin to the ITT Claude Code marketplace — a LinkedIn personal brand advisor that drafts posts, comments, and content calendars in the user's authentic voice.

## What's Included

### Plugin structure
```
plugins/linkedin-strategy/
├── .claude-plugin/plugin.json
├── README.md
└── skills/linkedin-strategy/
    ├── SKILL.md
    └── references/
        ├── voice-profile.md         ← per-person config (fill in once at install)
        ├── my-linkedin-feed.md      ← auto-populated from user's LinkedIn profile
        └── others-linkedin-feed.md  ← auto-populated from watched profiles
```

### Key capabilities
- **Voice-matched drafting** — posts, comments, carousels, article outlines, video scripts
- **Auto-fetch on session start** — uses Claude in Chrome to pull recent LinkedIn posts from the user's profile and watched profiles at the start of every session (non-blocking, fails gracefully)
- **On-demand refresh** — user can say "refresh my LinkedIn feed" or "fetch posts from [name]" at any time
- **Voice calibration** — feed posts are used to calibrate sentence rhythm, opening/closing style, and recurring patterns
- **Engagement strategy** — others' feed informs who to comment on and why
- **Content calendar** — topic suggestions based on what has already been posted

### Configuration (one-time)
After installing, the user fills in `references/voice-profile.md` with:
- Their LinkedIn profile URL and watched profile URLs
- Their goals, topics, colleagues, and sample posts

Pre-configured with Cody's voice profile (VP of Technology, In Time Tec) as the default.

## Marketplace Registration
- Added to `.claude-plugin/marketplace.json`
- Added to root `README.md` plugin table

## Install (once merged)
```shell
/plugin install linkedin-strategy@itt-plugins
```
